### PR TITLE
Устранение race condition при загрузке записей и единый опрос offline-событий

### DIFF
--- a/Lib/Bitrix24Integration.php
+++ b/Lib/Bitrix24Integration.php
@@ -659,6 +659,10 @@ class Bitrix24Integration extends PbxExtensionBase
                 if ($tmpFile !== '' && file_exists($tmpFile)) {
                     unlink($tmpFile);
                 }
+                return [
+                    'error' => 'ffmpeg_failed',
+                    'error_description' => 'ffmpeg conversion failed, upload aborted',
+                ];
             }
         }
         $post = ['file'=> curl_file_create($uploadFile)];

--- a/Lib/Bitrix24Integration.php
+++ b/Lib/Bitrix24Integration.php
@@ -582,6 +582,11 @@ class Bitrix24Integration extends PbxExtensionBase
 
         usleep(500000);
         $binds  = $eventResults['result']['result']['event.get'] ?? [];
+        static $subscriptionsLogged = false;
+        if (!$subscriptionsLogged) {
+            $this->mainLogger->writeInfo(json_encode($binds, JSON_UNESCAPED_UNICODE), 'event.get subscriptions');
+            $subscriptionsLogged = true;
+        }
         $events = [];
         foreach ($binds as $bind) {
             $events[] = $bind['event'];

--- a/bin/UploaderB24.php
+++ b/bin/UploaderB24.php
@@ -22,6 +22,7 @@ require_once 'Globals.php';
 
 use MikoPBX\Core\System\BeanstalkClient;
 use Exception;
+use MikoPBX\Core\System\Util;
 use MikoPBX\Core\Workers\WorkerBase;
 use Modules\ModuleBitrix24Integration\Lib\Bitrix24Integration;
 use Modules\ModuleBitrix24Integration\Lib\Logger;
@@ -32,17 +33,21 @@ class UploaderB24 extends WorkerBase
     private Bitrix24Integration $b24;
     private BeanstalkClient $queueAgent;
     private Logger $logger;
-    private const FILE_POLL_INTERVAL = 2;
-    private const FILE_POLL_TIMEOUT  = 180;
-    private const MAX_UPLOAD_ATTEMPTS = 8;
-    private const RETRY_BASE_DELAY    = 5;
-    private const RETRY_MAX_DELAY     = 600;
+    private const FILE_POLL_INTERVAL   = 2;
+    private const FILE_POLL_TIMEOUT    = 180;
+    private const MAX_UPLOAD_ATTEMPTS  = 8;
+    private const RETRY_BASE_DELAY     = 5;
+    private const RETRY_MAX_DELAY      = 600;
+    private const FILE_STABLE_SECONDS  = 4;
+    private const FFPROBE_MIN_DURATION = 0.01;
 
     /**
      * Pending upload tasks waiting for file to appear on disk.
      * Each element: ['FILENAME' => ..., 'uploadUrl' => ..., '_receivedAt' => time()]
      */
     private array $pendingTasks = [];
+
+    private string $ffprobePath = '';
 
     /**
      * Начало работы демона.
@@ -55,6 +60,8 @@ class UploaderB24 extends WorkerBase
         $this->logger->writeInfo('Start daemon...');
 
         $this->b24    = new Bitrix24Integration('_uploader');
+        $this->ffprobePath = Util::which('ffprobe') ?: '';
+        $this->logger->writeInfo("ffprobe path: '{$this->ffprobePath}'");
         $this->initBeanstalk();
         $this->logger->writeInfo('Start waiting...');
         while (!$this->needRestart) {
@@ -112,9 +119,9 @@ class UploaderB24 extends WorkerBase
                 $this->logger->writeError('Empty filename, skipping task.');
                 continue;
             }
-            if (!file_exists($filename)) {
+            if (!$this->isFileReady($task, $now)) {
                 if ($elapsed >= self::FILE_POLL_TIMEOUT) {
-                    $this->requeueWithDelay($task, "file not found after {$elapsed}s");
+                    $this->requeueWithDelay($task, "file not ready after {$elapsed}s");
                 } else {
                     $remaining[] = $task;
                 }
@@ -159,7 +166,7 @@ class UploaderB24 extends WorkerBase
         }
         $delay = (int)min(self::RETRY_BASE_DELAY * pow(2, $attempts - 1), self::RETRY_MAX_DELAY);
         $task['_attempts'] = $attempts;
-        unset($task['_receivedAt']);
+        unset($task['_receivedAt'], $task['_lastSize'], $task['_stableSince']);
         $this->queueAgent->publish(
             json_encode($task, JSON_UNESCAPED_SLASHES),
             self::B24_UPLOADER_CHANNEL,
@@ -167,6 +174,56 @@ class UploaderB24 extends WorkerBase
             $delay
         );
         $this->logger->writeInfo("Requeued '$filename', attempt $attempts, delay {$delay}s. Reason: $reason");
+    }
+
+    /**
+     * Файл считается готовым только когда размер не менялся FILE_STABLE_SECONDS
+     * и ffprobe подтверждает валидный Matroska контейнер. WorkerWav2Webm пишет
+     * ffmpeg'ом прямо в целевой .webm без atomic rename, поэтому одного file_exists()
+     * недостаточно — состояние trackается между итерациями executeTasks().
+     */
+    private function isFileReady(array &$task, int $now): bool
+    {
+        $filename = $task['FILENAME'] ?? '';
+        if ($filename === '' || !file_exists($filename)) {
+            return false;
+        }
+        $size = @filesize($filename);
+        if ($size === false || $size <= 0) {
+            return false;
+        }
+        $lastSize    = $task['_lastSize']    ?? -1;
+        $stableSince = $task['_stableSince'] ?? 0;
+        if ($size !== $lastSize) {
+            $task['_lastSize']    = $size;
+            $task['_stableSince'] = $now;
+            return false;
+        }
+        if (($now - $stableSince) < self::FILE_STABLE_SECONDS) {
+            return false;
+        }
+        return $this->isWebmValid($filename);
+    }
+
+    private function isWebmValid(string $filename): bool
+    {
+        if (strtolower(pathinfo($filename, PATHINFO_EXTENSION)) !== 'webm') {
+            return true;
+        }
+        if ($this->ffprobePath === '') {
+            return true;
+        }
+        $cmd = escapeshellcmd($this->ffprobePath)
+            . ' -v error -show_entries format=duration -of default=nw=1:nk=1 '
+            . escapeshellarg($filename)
+            . ' 2>/dev/null';
+        $out = [];
+        $rc  = 0;
+        exec($cmd, $out, $rc);
+        if ($rc !== 0 || empty($out)) {
+            return false;
+        }
+        return (float)trim($out[0]) >= self::FFPROBE_MIN_DURATION;
     }
 
     /**

--- a/bin/WorkerBitrix24IntegrationHTTP.php
+++ b/bin/WorkerBitrix24IntegrationHTTP.php
@@ -34,7 +34,6 @@ class WorkerBitrix24IntegrationHTTP extends WorkerBase
     private $pidSyncProcContacts;
     private $timeSyncProcContacts;
     private array $q_req = [];
-    private bool $need_get_events = false;
     private int $last_update_inner_num = 0;
     private BeanstalkClient $queueAgent;
 
@@ -483,6 +482,14 @@ class WorkerBitrix24IntegrationHTTP extends WorkerBase
     }
 
     /**
+     * Тонкая обёртка: оборачивает events в формат, ожидаемый handleEvent().
+     */
+    private function processOfflineEvents(array $events): void
+    {
+        $this->handleEvent(['event.offline.get' => ['events' => $events]]);
+    }
+
+    /**
      * Обработка событий b24.
      * @param $result
      * @return void
@@ -808,6 +815,17 @@ class WorkerBitrix24IntegrationHTTP extends WorkerBase
             if ($this->needRestart) {
                 return;
             }
+            // Прямой опрос offline-событий — гарантированно каждые ~10с.
+            $evResponse = $this->b24->sendBatch($this->b24->eventOfflineGet());
+            $offlineEvents = $evResponse['result']['result']['event.offline.get']['events'] ?? [];
+            if (!empty($offlineEvents)) {
+                $evCount = count($offlineEvents);
+                $this->b24->mainLogger->writeInfo(
+                    "event.offline.get: {$evCount} events: "
+                    . json_encode(array_column($offlineEvents, 'EVENT_NAME'))
+                );
+                $this->processOfflineEvents($offlineEvents);
+            }
             if ($this->b24->getAuthFailureCount() >= Bitrix24Integration::AUTH_FAILURE_THRESHOLD) {
                 $this->b24->mainLogger->writeError(
                     'Auth failure threshold reached (' . $this->b24->getAuthFailureCount() . '), restarting worker'
@@ -862,17 +880,9 @@ class WorkerBitrix24IntegrationHTTP extends WorkerBase
             return;
         }
 
-        // Получать новые события будем каждое 2ое обращение к этой функции ~ 1.2 секунды.
-        $this->need_get_events = !$this->need_get_events;
-
         // Обработка очередей: все доступные события для каждого вызова
         $this->drainPerCallQueues();
 
-        if ($this->need_get_events) {
-            // Запрос на получение offline событий.
-            $arg = $this->b24->eventOfflineGet();
-            $this->q_req = array_merge($this->q_req, $arg);
-        }
         if (count($this->q_req) > 0) {
             $this->processState = 'sendBatch';
             $chunks = $this->chunkAssociativeArray($this->q_req);


### PR DESCRIPTION
## Summary

- **Race condition при загрузке .webm в Bitrix24.** `WorkerWav2Webm` пишет ffmpeg'ом прямо в целевой `.webm` без atomic rename, а `WorkerCdr` публикует `recordingfile` в CDR до окончания конвертации. `UploaderB24` по `file_exists()` успевал захватить неполный Matroska контейнер и падал с `"Wrong file extension"`. Добавлена двухступенчатая проверка готовности: стабильность размера 4с + валидация `ffprobe`. State хранится в `pendingTasks` и сбрасывается в `requeueWithDelay()`. В `uploadRecord()` при fail ffmpeg теперь возвращаем ошибку вместо молчаливого fallback на битый `.webm`.
- **Единая точка опроса offline-событий.** Убран тройной вызов `event.offline.get` в одном цикле `executeTasksInner` (в `eventsBind`, в q_req батче и без throttle) — приводил к повторной обработке одних и тех же `ONCRMCONTACTUPDATE` и лишним REST-вызовам. Оставлен один явный `sendBatch(eventOfflineGet())` раз в ~10с после `checkNeedUpdateToken`. Поле `need_get_events` удалено. Логирование `event.offline.get` пишется только когда есть новые события. Добавлен диагностический one-shot лог `event.get subscriptions` при старте процесса.

## Test plan

- [x] `php -l` на изменённых файлах
- [x] Боевой прогон на `boffart.miko.ru`: исходящий звонок с 201 → `File ready after 8s` → `Upload OK. FILE_ID: 97`
- [x] В `UploaderB24.log` и `HttpConnection_uploader.log` после фикса не появилось ни одного `"Wrong file extension"` / `"ffmpeg convert failed"`
- [x] Проверено отсутствие шума `"event.offline.get: 0 events"` в `HttpConnection.log`
- [x] Проверено что `attachRecord` вызывается один раз за звонок, а не трижды