### PR TITLE
Добавлена зависимость cesargb/php-log-rotation в composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "mikopbx/modulebitrix24integration",
     "description": "ModuleBitrix24Integration",
     "require": {
-        "php": "7.4"
+        "php": ">=7.4",
+        "cesargb/php-log-rotation": ">=2.5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Logger.php использует Cesargb\Log\Rotation, но пакет не был указан в composer.json. При сборке через GitHub Actions vendor/ не содержал этот пакет, что приводило к падению всех воркеров при старте.