### PR TITLE
Сброс needRestart после init в AMI-воркере

### DIFF
--- a/bin/WorkerBitrix24IntegrationAMI.php
+++ b/bin/WorkerBitrix24IntegrationAMI.php
@@ -109,6 +109,10 @@ class WorkerBitrix24IntegrationAMI extends WorkerBase
         $this->extensionLength = $config->getGeneralSettings('PBXInternalExtensionLength');
 
         $this->am->addEventHandler("userevent", [$this, "callback"]);
+        if ($this->needRestart) {
+            $this->logger->writeInfo('Restart signal received during init, deferring — entering main loop.');
+            $this->needRestart = false;
+        }
         $this->processState = 'idle';
         while ($this->needRestart === false) {
             $this->processState = 'wait_ami';


### PR DESCRIPTION
Если safe.php присылает SIGUSR1 во время длительной инициализации (подключение к Bitrix24 API может занимать 10-30с), needRestart ставился в true до входа в main loop — воркер сразу завершался, не обработав ни одного события. На медленном портале это приводило к хроническому restart-циклу.

Теперь restart-сигнал, полученный во время init, откладывается — воркер входит в main loop и будет корректно перезапущен при следующем сигнале.