### PR TITLE
fix: защита от Undefined array key NAME/LAST_NAME в b24GetPhones

### DIFF
--- a/Lib/Bitrix24Integration.php
+++ b/Lib/Bitrix24Integration.php
@@ -929,7 +929,7 @@ class Bitrix24Integration extends PbxExtensionBase
             $this->b24Users = [];
             foreach ($users_list['result'] as $value) {
                 $user                    = [];
-                $user['NAME']            = '' . $value['NAME'] . ' ' . $value['LAST_NAME'];
+                $user['NAME']            = '' . ($value['NAME'] ?? '') . ' ' . ($value['LAST_NAME'] ?? '');
                 $user['ID']              = $value['ID'];
                 $user['PERSONAL_MOBILE'] = preg_replace('/(\D)/', '', $value['PERSONAL_MOBILE']??'');
                 $user['WORK_PHONE']      = preg_replace('/(\D)/', '', $value['WORK_PHONE']??'');

--- a/bin/ConnectorDb.php
+++ b/bin/ConnectorDb.php
@@ -938,7 +938,7 @@ class ConnectorDb extends WorkerBase
             $dateModify  = $entData['DATE_MODIFY'];
             $statusLeadId= $entData['STATUS_SEMANTIC_ID']??'';
             if(Bitrix24Integration::API_CRM_LIST_CONTACT === $action){
-                $name  = $entData['LAST_NAME'] ." " . $entData['NAME']. " " . $entData['SECOND_NAME'];
+                $name  = ($entData['LAST_NAME'] ?? '') ." " . ($entData['NAME'] ?? ''). " " . ($entData['SECOND_NAME'] ?? '');
             }else{
                 $name  = $entData['TITLE'];
             }


### PR DESCRIPTION
AMI-воркер падал Undefined array key "NAME") при сотруднике B24 без заполненного NAME/LAST_NAME в ответе user.get — error-handler эскалирует warning в исключение, safe.php рестартит по кругу, core отключает модуль. Добавлен ?? '' как у соседних полей.

Тот же дефект превентивно закрыт в ConnectorDb::action... для контактов CRM (LAST_NAME/NAME/SECOND_NAME).